### PR TITLE
launcher: add version check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
 	<groupId>net.runelite</groupId>
 	<artifactId>launcher</artifactId>
-	<version>1.6.3-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>RuneLite Launcher</name>
 	<description>Launcher for RuneLite client</description>
 
@@ -83,6 +83,11 @@
 	</pluginRepositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.vdurmont</groupId>
+			<artifactId>semver4j</artifactId>
+			<version>2.2.0</version>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -337,6 +337,10 @@ public class Launcher
 
 	private static boolean checkVersion(Bootstrap bootstrap)
 	{
+		if(bootstrap.getMinimumLauncherVersion() == null || PROPERTIES.getVersion() == null)
+		{
+			return true;
+		}
 		Semver minimum = new Semver(bootstrap.getMinimumLauncherVersion()).withClearedSuffixAndBuild();
 		Semver ours = new Semver(PROPERTIES.getVersion()).withClearedSuffixAndBuild();
 		return !ours.isLowerThan(minimum);

--- a/src/main/java/net/runelite/launcher/beans/Bootstrap.java
+++ b/src/main/java/net/runelite/launcher/beans/Bootstrap.java
@@ -36,4 +36,6 @@ public class Bootstrap
 	private String[] launcherWindowsArguments;
 	private String[] launcherMacArguments;
 	private String[] launcherArguments;
+
+	private String minimumLauncherVersion;
 }


### PR DESCRIPTION
Adding in anticipation of the automatic bootstrapper I'll be pushing to runelite-extended/bootstrapper soon, so we can notify users using old launchers, and old bootstraps.
Will also PR something similar to the client for an outdated launcher notification, if a user doesn't have a launcher with this check in it.