### PR TITLE
launcher: Added check for shaded jar file

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -6,6 +6,13 @@ JDK_VER="11.0.4"
 JDK_BUILD="11"
 PACKR_VERSION="runelite-1.0"
 
+# Check if there's a client jar file - If there's no file the AppImage will not work but will still be built.
+if ! [ -e build/libs/OpenOSRS-shaded.jar ]
+then
+  echo "build/libs/OpenOSRS-shaded.jar not found, exiting"
+  exit 1
+fi
+
 if ! [ -f OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz


### PR DESCRIPTION
I noticed with the latest launcher, the AppImage doesn't work, well I found out it's because it's missing the file OpenOSRS-shaded.jar, I added a check in the build script so it'll exit if none was found, since it'll still try to build an AppImage without the jar, causing this error.

`Exception in thread "main" java.lang.ClassNotFoundException: net.runelite.launcher.Launcher
	at java.base/java.net.URLClassLoader.findClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
Error: failed to load/find main class net.runelite.launcher.Launcher
`