### PR TITLE
launcher: update to jdk 11.0.8_10

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -19,9 +19,6 @@ if ! [ -f OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; th
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
 fi
 
-rm -f packr.jar
-curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
-
 echo "98615b1b369509965a612232622d39b5cefe117d6189179cbad4dcef2ee2f4e1 OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | sha256sum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -2,9 +2,10 @@
 
 set -e
 
-JDK_VER="11.0.4"
-JDK_BUILD="11"
-PACKR_VERSION="runelite-1.0"
+JDK_VER="11.0.8"
+JDK_BUILD="10"
+PACKR_VERSION="runelite-1.3"
+APPIMAGE_VERSION="12"
 
 # Check if there's a client jar file - If there's no file the AppImage will not work but will still be built.
 if ! [ -e build/libs/OpenOSRS-shaded.jar ]
@@ -21,14 +22,14 @@ fi
 rm -f packr.jar
 curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
 
-echo "70d2cc675155476f1d8516a7ae6729d44681e4fad5a6fc8dfa65cab36a67b7e0 OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | sha256sum -c
+echo "98615b1b369509965a612232622d39b5cefe117d6189179cbad4dcef2ee2f4e1 OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | sha256sum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside
 # the jdk folder at jre/
 if ! [ -d linux-jdk ] ; then
     tar zxf OpenJDK11U-jre_x64_linux_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
     mkdir linux-jdk
-    mv jdk-11.0.4+11-jre linux-jdk/jre
+    mv jdk-$JDK_VER+$JDK_BUILD-jre linux-jdk/jre
 fi
 
 if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
@@ -36,7 +37,7 @@ if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
         https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
 fi
 
-echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+echo "f200fb7088dbb5e61e0835fe7b0d7fc1310beda192dacd764927567dcd7c4f0f  packr_${PACKR_VERSION}.jar" | sha256sum -c
 
 java -jar packr_${PACKR_VERSION}.jar \
     --platform \

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-JDK_VER="11.0.4"
-JDK_BUILD="11"
-PACKR_VERSION="runelite-1.0"
+JDK_VER="11.0.14.1"
+JDK_BUILD="1"
+PACKR_VERSION="runelite-1.4"
 
 SIGNING_IDENTITY="Developer ID Application"
 ALTOOL_USER="user@icloud.com"
@@ -12,20 +12,20 @@ ALTOOL_PASS="@keychain:altool-password"
 
 if ! [ -f OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
-        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
+        https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
 fi
 
 rm -f packr.jar
 curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
 
-echo "1647fded28d25e562811f7bce2092eb9c21d30608843b04250c023b40604ff26  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
+echo "1b2f792ad05af9dba876db962c189527e645b48f50ceb842b4e39169de553303  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside
 # the jdk folder at jre/
 if ! [ -d osx-jdk ] ; then
     tar zxf OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
     mkdir osx-jdk
-    mv jdk-11.0.4+11-jre osx-jdk/jre
+    mv jdk-${JDK_VER}+${JDK_BUILD}-jre osx-jdk/jre
 
     # Move JRE out of Contents/Home/
     pushd osx-jdk/jre
@@ -38,7 +38,7 @@ if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
         https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
 fi
 
-echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | shasum -c
+echo "f51577b005a51331b822a18122ce08fca58cf6fee91f071d5a16354815bbe1e3  packr_${PACKR_VERSION}.jar" | shasum -c
 
 java -jar packr_${PACKR_VERSION}.jar \
     --platform \
@@ -69,7 +69,7 @@ pushd native-osx/OpenOSRS.app
 chmod g+x,o+x Contents/MacOS/OpenOSRS
 popd
 
-codesign -f -s "${SIGNING_IDENTITY}" --entitlements osx/signing.entitlements --options runtime native-osx/RuneLite.app || true
+codesign -f -s "${SIGNING_IDENTITY}" --entitlements osx/signing.entitlements --options runtime native-osx/OpenOSRS.app || true
 
 # create-dmg exits with an error code due to no code signing, but is still okay
 # note we use Adam-/create-dmg as upstream does not support UDBZ

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -4,7 +4,7 @@ set -e
 
 JDK_VER="11.0.8"
 JDK_BUILD="10"
-PACKR_VERSION="runelite-1.0"
+PACKR_VERSION="runelite-1.4"
 
 SIGNING_IDENTITY="Developer ID Application"
 ALTOOL_USER="user@icloud.com"
@@ -14,9 +14,6 @@ if ! [ -f OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
 fi
-
-rm -f packr.jar
-curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
 
 echo "b0cd349e7e428721a3bcfec619e071d25c0397e3e43b7ce22acfd7d834a8ca4b  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
 
@@ -42,7 +39,7 @@ echo "f51577b005a51331b822a18122ce08fca58cf6fee91f071d5a16354815bbe1e3  packr_${
 
 java -jar packr_${PACKR_VERSION}.jar \
     --platform \
-    mac \
+    mac64 \
     --icon \
     packr/openosrs.icns \
     --jdk \
@@ -73,7 +70,7 @@ codesign -f -s "${SIGNING_IDENTITY}" --entitlements osx/signing.entitlements --o
 
 # create-dmg exits with an error code due to no code signing, but is still okay
 # note we use Adam-/create-dmg as upstream does not support UDBZ
-create-dmg --format UDBZ native-osx/OpenOSRS.app.app native-osx/ || true
+create-dmg --format UDBZ native-osx/OpenOSRS.app native-osx/ || true
 
 mv native-osx/OpenOSRS\ *.dmg native-osx/OpenOSRS.dmg
 

--- a/build-osx.sh
+++ b/build-osx.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-JDK_VER="11.0.14.1"
-JDK_BUILD="1"
-PACKR_VERSION="runelite-1.4"
+JDK_VER="11.0.8"
+JDK_BUILD="10"
+PACKR_VERSION="runelite-1.0"
 
 SIGNING_IDENTITY="Developer ID Application"
 ALTOOL_USER="user@icloud.com"
@@ -12,13 +12,13 @@ ALTOOL_PASS="@keychain:altool-password"
 
 if ! [ -f OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz ] ; then
     curl -Lo OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz \
-        https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
+        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz
 fi
 
 rm -f packr.jar
 curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
 
-echo "1b2f792ad05af9dba876db962c189527e645b48f50ceb842b4e39169de553303  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
+echo "b0cd349e7e428721a3bcfec619e071d25c0397e3e43b7ce22acfd7d834a8ca4b  OpenJDK11U-jre_x64_mac_hotspot_${JDK_VER}_${JDK_BUILD}.tar.gz" | shasum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside
 # the jdk folder at jre/

--- a/build-win32.sh
+++ b/build-win32.sh
@@ -2,26 +2,27 @@
 
 set -e
 
-JDK_VER="11.0.4"
-JDK_BUILD="11"
-PACKR_VERSION="runelite-1.0"
+JDK_VER="11.0.8"
+JDK_BUILD="10"
+JDK_BUILD_SHORT="10"
+PACKR_VERSION="runelite-1.3"
 
 if ! [ -f OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip ] ; then
     curl -Lo OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip \
-        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip
+        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD_SHORT}.zip
 fi
 
 rm -f packr.jar
 curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
 
-echo "24eb66c5858c09c58a50b51df98b8dd6f75151a2b9f8e2e822441fa9f29009b6 OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip" | sha256sum -c
+echo "00e0eb7112a4cdbaae663110e4c7af6377d2fa01f69c20222790293b4f427f26 OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip" | sha256sum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside
 # the jdk folder at jre/
 if ! [ -d win32-jdk ] ; then
     unzip OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip
     mkdir win32-jdk
-    mv jdk-11.0.4+11-jre win32-jdk/jre
+    mv jdk-$JDK_VER+$JDK_BUILD_SHORT-jre win32-jdk/jre
 fi
 
 if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
@@ -29,7 +30,7 @@ if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
         https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
 fi
 
-echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+echo "f200fb7088dbb5e61e0835fe7b0d7fc1310beda192dacd764927567dcd7c4f0f  packr_${PACKR_VERSION}.jar" | sha256sum -c
 
 java -jar packr_${PACKR_VERSION}.jar \
     --platform \

--- a/build-win32.sh
+++ b/build-win32.sh
@@ -12,9 +12,6 @@ if ! [ -f OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip ] ; 
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD_SHORT}.zip
 fi
 
-rm -f packr.jar
-curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
-
 echo "00e0eb7112a4cdbaae663110e4c7af6377d2fa01f69c20222790293b4f427f26 OpenJDK11U-jre_x86-32_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip" | sha256sum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside

--- a/build-win64.sh
+++ b/build-win64.sh
@@ -2,26 +2,27 @@
 
 set -e
 
-JDK_VER="11.0.4"
-JDK_BUILD="11"
-PACKR_VERSION="runelite-1.0"
+JDK_VER="11.0.8"
+JDK_BUILD="10"
+JDK_BUILD_SHORT="10"
+PACKR_VERSION="runelite-1.3"
 
 if ! [ -f OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip ] ; then
     curl -Lo OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip \
-        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip
+        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD_SHORT}.zip
 fi
 
 rm -f packr.jar
 curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
 
-echo "be88c679fd24194bee71237f92f7a2a71c88f71a853a56a7c05742b0e158c1be OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip" | sha256sum -c
+echo "fefa05395dbccfe072a8b6fbfebecf797ed81e18cb1aa4ed093c653d316b3f56 OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip" | sha256sum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside
 # the jdk folder at jre/
 if ! [ -d win64-jdk ] ; then
     unzip OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip
     mkdir win64-jdk
-    mv jdk-11.0.4+11-jre win64-jdk/jre
+    mv jdk-$JDK_VER+$JDK_BUILD_SHORT-jre win64-jdk/jre
 fi
 
 if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
@@ -29,7 +30,7 @@ if ! [ -f packr_${PACKR_VERSION}.jar ] ; then
         https://github.com/runelite/packr/releases/download/${PACKR_VERSION}/packr.jar
 fi
 
-echo "18b7cbaab4c3f9ea556f621ca42fbd0dc745a4d11e2a08f496e2c3196580cd53  packr_${PACKR_VERSION}.jar" | sha256sum -c
+echo "f200fb7088dbb5e61e0835fe7b0d7fc1310beda192dacd764927567dcd7c4f0f  packr_${PACKR_VERSION}.jar" | sha256sum -c
 
 java -jar packr_${PACKR_VERSION}.jar \
     --platform \

--- a/build-win64.sh
+++ b/build-win64.sh
@@ -12,9 +12,6 @@ if ! [ -f OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip ] ; the
         https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JDK_VER}%2B${JDK_BUILD}/OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD_SHORT}.zip
 fi
 
-rm -f packr.jar
-curl -o packr.jar https://libgdx.badlogicgames.com/ci/packr/packr.jar
-
 echo "fefa05395dbccfe072a8b6fbfebecf797ed81e18cb1aa4ed093c653d316b3f56 OpenJDK11U-jre_x64_windows_hotspot_${JDK_VER}_${JDK_BUILD}.zip" | sha256sum -c
 
 # packr requires a "jdk" and pulls the jre from it - so we have to place it inside

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
-version = '2.2.0'
+version = '2.2.1'
 */
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.apache.tools.ant.filters.ReplaceTokens
@@ -9,14 +9,14 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.github.ben-manes:gradle-versions-plugin:0.28.0")
+        classpath("com.github.ben-manes:gradle-versions-plugin:0.42.0")
     }
 }
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "6.0.0"
-    id("com.github.ben-manes.versions") version "0.28.0"
-    id("se.patrikerdes.use-latest-versions") version "0.2.14"
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("com.github.ben-manes.versions") version "0.42.0"
+    id("se.patrikerdes.use-latest-versions") version "0.2.18"
 
     java
     checkstyle
@@ -38,16 +38,16 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor(group = "org.projectlombok", name = "lombok", version = "1.18.12")
+    annotationProcessor(group = "org.projectlombok", name = "lombok", version = "1.18.22")
 
 
-    compileOnly(group = "org.projectlombok", name = "lombok", version = "1.18.12")
+    compileOnly(group = "org.projectlombok", name = "lombok", version = "1.18.22")
 
-    implementation(group = "org.slf4j", name = "slf4j-api", version = "1.7.30")
-    implementation(group = "ch.qos.logback", name = "logback-classic", version = "1.2.3")
+    implementation(group = "org.slf4j", name = "slf4j-api", version = "1.7.36")
+    implementation(group = "ch.qos.logback", name = "logback-classic", version = "1.2.11")
     implementation(group = "net.sf.jopt-simple", name = "jopt-simple", version = "5.0.4")
-    implementation(group = "com.google.code.gson", name = "gson", version = "2.8.6")
-    implementation(group = "com.google.guava", name = "guava", version = "29.0-jre")
+    implementation(group = "com.google.code.gson", name = "gson", version = "2.8.9")
+    implementation(group = "com.google.guava", name = "guava", version = "31.1-jre")
     implementation(group = "com.vdurmont", name = "semver4j", version = "3.1.0")
 
     testImplementation(group = "junit", name = "junit", version = "4.13")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "com.openosrs"
-version = "2.2.0"
+version = "2.2.1"
 description = "OpenOSRS Launcher"
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/innosetup/openosrs.iss
+++ b/innosetup/openosrs.iss
@@ -3,6 +3,7 @@ AppName=OpenOSRS Launcher
 AppPublisher=OpenOSRS
 UninstallDisplayName=OpenOSRS
 AppVersion=@project.version@
+VersionInfoVersion=@project.version@
 AppSupportURL=https://openosrs.com/
 DefaultDirName={localappdata}\OpenOSRS
 ; vcredist queues files to be replaced at next reboot, however it doesn't seem to matter

--- a/innosetup/openosrs32.iss
+++ b/innosetup/openosrs32.iss
@@ -3,6 +3,7 @@ AppName=OpenOSRS Launcher
 AppPublisher=OpenOSRS
 UninstallDisplayName=OpenOSRS
 AppVersion=@project.version@
+VersionInfoVersion=@project.version@
 AppSupportURL=https://openosrs.com/
 DefaultDirName={localappdata}\OpenOSRS
 ; vcredist queues files to be replaced at next reboot, however it doesn't seem to matter

--- a/src/main/java/net/runelite/launcher/InfoPanel.java
+++ b/src/main/java/net/runelite/launcher/InfoPanel.java
@@ -67,7 +67,7 @@ class InfoPanel extends JPanel
 	private static final Dimension VERSION_SIZE = new Dimension(PANEL_SIZE.width, 25);
 
 	private static final String TROUBLESHOOTING_URL = "https://github.com/runelite/runelite/wiki/Troubleshooting-problems-with-the-client";
-	private static final String DISCORD_INVITE_LINK = "https://discordapp.com/invite/openosrs";
+	private static final String DISCORD_INVITE_LINK = "https://discord.gg/openosrs";
 	private static final String LAUNCHER_DOWNLOAD_LINK = "https://github.com/open-osrs/launcher/releases";
 
 	InfoPanel(String mode)

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -70,16 +70,15 @@ public class Launcher
 {
 	private static final File RUNELITE_DIR = new File(System.getProperty("user.home"), ".openosrs");
 	private static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
-	private static final File REPO_DIR = new File(RUNELITE_DIR, "repository2");
+	private static final File REPO_DIR = new File(RUNELITE_DIR, "repository");
 	private static final File CRASH_FILES = new File(LOGS_DIR, "jvm_crash_pid_%p.log");
 	static final String LAUNCHER_BUILD = "https://raw.githubusercontent.com/open-osrs/launcher/master/build.gradle.kts";
-	private static final String CLIENT_BOOTSTRAP_STAGING_URL = "https://raw.githubusercontent.com/open-osrs/hosting/master/bootstrap-staging.json";
-	private static final String CLIENT_BOOTSTRAP_STABLE_URL = "https://raw.githubusercontent.com/open-osrs/hosting/master/bootstrap-openosrs.json";
+	private static final String CLIENT_BOOTSTRAP_NIGHTLY_URL = "https://raw.githubusercontent.com/open-osrs/hosting/master/bootstrap-nightly.json";
+	private static final String CLIENT_BOOTSTRAP_STABLE_URL = "https://raw.githubusercontent.com/open-osrs/hosting/master/bootstrap-stable.json";
 	static final String USER_AGENT = "OpenOSRS/" + LauncherProperties.getVersion();
 	private static final boolean enforceDependencyHashing = true;
 	private static boolean nightly = false;
-	private static boolean staging = false;
-	private static boolean stable = true;
+	private static boolean stable = false;
 
 	static final String CLIENT_MAIN_CLASS = "net.runelite.client.RuneLite";
 
@@ -105,7 +104,6 @@ public class Launcher
 		parser.accepts("forcejvm");
 		parser.accepts("debug");
 		parser.accepts("nightly");
-		parser.accepts("staging");
 		parser.accepts("stable");
 
 		HardwareAccelerationMode defaultMode;
@@ -152,7 +150,6 @@ public class Launcher
 		}
 
 		nightly |= options.has("nightly");
-		staging = options.has("staging");
 
 		LOGS_DIR.mkdirs();
 
@@ -163,7 +160,7 @@ public class Launcher
 			logger.setLevel(Level.DEBUG);
 		}
 
-		if (!nightly && !staging && !stable)
+		if (!nightly && !stable)
 		{
 			OpenOSRSSplashScreen.init(null);
 			OpenOSRSSplashScreen.barMessage(null);
@@ -199,7 +196,7 @@ public class Launcher
 	{
 		try
 		{
-			OpenOSRSSplashScreen.init(nightly ? "Nightly" : stable ? "Stable" : "Staging");
+			OpenOSRSSplashScreen.init(nightly ? "Nightly" : stable ? "Stable" : "Unknown");
 			OpenOSRSSplashScreen.stage(0, "Setting up environment");
 
 			log.info("OpenOSRS Launcher version {}", LauncherProperties.getVersion());
@@ -404,9 +401,9 @@ public class Launcher
 	private static Bootstrap getBootstrap() throws IOException
 	{
 		URL u;
-		if (staging)
+		if (nightly)
 		{
-			u = new URL(CLIENT_BOOTSTRAP_STAGING_URL);
+			u = new URL(CLIENT_BOOTSTRAP_NIGHTLY_URL);
 		}
 		else if (stable)
 		{

--- a/src/main/java/net/runelite/launcher/Launcher.java
+++ b/src/main/java/net/runelite/launcher/Launcher.java
@@ -149,7 +149,9 @@ public class Launcher
 			}
 		}
 
+		stable |= options.has("stable");
 		nightly |= options.has("nightly");
+
 
 		LOGS_DIR.mkdirs();
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -31,11 +31,11 @@
 	</appender>
 
 	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>${user.home}/.runelite/logs/launcher.log</file>
+		<file>${user.home}/.openosrs/logs/launcher.log</file>
 
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 			<!-- daily rollover -->
-			<fileNamePattern>${user.home}/.runelite/logs/launcher_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+			<fileNamePattern>${user.home}/.openosrs/logs/launcher_%d{yyyy-MM-dd}.%i.log</fileNamePattern>
 
 			<!-- when file size is larger than defined, roll to new file -->
 			<timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">


### PR DESCRIPTION
bumps native launcher to use jdk 11.0.8_10 (fixes fps issue)
untested on linux and macos (don't have access to devices)
stills needs to be bootstrapped, built and released